### PR TITLE
Load routes and commands in the service provider's boot method

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,8 +26,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $configPath = __DIR__ . '/../config/debugbar.php';
         $this->mergeConfigFrom($configPath, 'debugbar');
 
-        $this->loadRoutesFrom(realpath(__DIR__ . '/debugbar-routes.php'));
-
         $this->app->alias(
             DataFormatter::class,
             DataFormatterInterface::class
@@ -91,8 +89,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             }
         );
 
-        $this->commands(['command.debugbar.clear']);
-
         Collection::macro('debug', function () {
             debug($this);
             return $this;
@@ -109,7 +105,13 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $configPath = __DIR__ . '/../config/debugbar.php';
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
+        $this->loadRoutesFrom(realpath(__DIR__ . '/debugbar-routes.php'));
+
         $this->registerMiddleware(InjectDebugbar::class);
+
+        if ($this->app->runningInConsole()) {
+            $this->commands(['command.debugbar.clear']);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR move routes and commands loading in the `boot` method to avoid incompatibilities with other plugins (ex: #1170, #1149, #1125). 

As described in [Laravel's documentation](https://laravel.com/docs/8.x/providers#the-register-method), routes and commands should be loaded in the `boot` method to avoid loading things are are not ready yet:

> As mentioned previously, within the register method, you should only bind things into the service container. You should never attempt to register any event listeners, routes, or any other piece of functionality within the register method. Otherwise, you may accidentally use a service that is provided by a service provider which has not loaded yet.

It seems a regression since PR #1055.